### PR TITLE
Update EventNavigationTweaks.php

### DIFF
--- a/EventNavigationTweaks.php
+++ b/EventNavigationTweaks.php
@@ -334,6 +334,10 @@ class EventNavigationTweaks extends AbstractExternalModule
                     'records' => $record,
                     'fields' => $Proj->table_pk
                 ));
+
+                if ($recordData[$record] == null) {
+                        return $events;  // null ??? is it useful or safe on the calling end, if we get a null, of getRecordEvents
+                }                
                 
                 $events = array();
 


### PR DESCRIPTION
Fix for PHP 8 NULL. 

Somehow an external project is triggering an error message. I tried to replicate the issue, but wasn't able to with limited time. This is a blind fix.

TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in /modules/event_navigation_tweaks_v1.1.0/EventNavigationTweaks.php:340 Stack trace:
#0 /modules/event_navigation_tweaks_v1.1.0/EventNavigationTweaks.php(340): array_keys()

Please double and triple check this fix :) 